### PR TITLE
Point get.volta.sh at new, faster install script

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [[redirects]]
   from = "/*"
 # FIXME: we should still use a function so this works from browsers too, and redirects to an MSI for Windows
-  to = "https://raw.githubusercontent.com/volta-cli/volta/master/dev/unix/boot-install.sh"
+  to = "https://raw.githubusercontent.com/volta-cli/volta/master/dev/unix/volta-install.sh"
   status = 302


### PR DESCRIPTION
Tested `volta-install.sh` on Mac and 9 varied Linux distros with different OpenSSL versions, no problems were found and the installer was significantly faster.