### PR TITLE
Use a proxy redirect to prevent needing -L in installer script

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,4 +2,4 @@
   from = "/*"
 # FIXME: we should still use a function so this works from browsers too, and redirects to an MSI for Windows
   to = "https://raw.githubusercontent.com/volta-cli/volta/master/dev/unix/volta-install.sh"
-  status = 302
+  status = 200


### PR DESCRIPTION
Closes https://github.com/volta-cli/volta/issues/457

Switching the `status` field to a `200` instead of a `302` should allow netlify to treat it as a proxy redirect, instead of an actual redirect. This will allow `curl https://get.volta.sh` to work without needing the `-L` flag.

Note: You can test this change using the deploy preview generated by netlify:

```bash
curl https://deploy-preview-3--wizardly-raman-b49c83.netlify.com/ | bash
```