### PR TITLE
Pin the installer version URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-Netlify repo for `get.jetson.sh`
+Netlify repo for `get.volta.sh`

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [[redirects]]
   from = "/*"
 # FIXME: we should still use a function so this works from browsers too, and redirects to an MSI for Windows
-  to = "https://raw.githubusercontent.com/volta-cli/volta/master/dev/unix/volta-install.sh"
+  to = "https://raw.githubusercontent.com/volta-cli/volta/e0290c2d7b0e80bf64e7c5d403789bc51678d16c/dev/unix/volta-install.sh"
   status = 200


### PR DESCRIPTION
As we work towards 0.7.0, we will make changes to the installer script to support the new installation flow. In order to keep working before we release 0.7.0, we need to pin the Netlify redirect here to the existing install script.

(Also updated the README to say `volta` instead of `jetson`)