### PR TITLE
Update branch in netlify redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [[redirects]]
   from = "/*"
 # FIXME: we should still use a function so this works from browsers too, and redirects to an MSI for Windows
-  to = "https://raw.githubusercontent.com/volta-cli/volta/master/dev/unix/volta-install.sh"
+  to = "https://raw.githubusercontent.com/volta-cli/volta/main/dev/unix/volta-install.sh"
   status = 200


### PR DESCRIPTION
Update the Netlify redirect settings to point to the new default branch in the main repo.