### PR TITLE
Pin get.volta.sh installer to current commit hash

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [[redirects]]
   from = "/*"
 # FIXME: we should still use a function so this works from browsers too, and redirects to an MSI for Windows
-  to = "https://raw.githubusercontent.com/volta-cli/volta/main/dev/unix/volta-install.sh"
+  to = "https://raw.githubusercontent.com/volta-cli/volta/8f2074f423c65405dfba9858d9bcf393c38ffb45/dev/unix/volta-install.sh"
   status = 200


### PR DESCRIPTION
# Info

* As part of migrating to use a statically-linked TLS provider (see https://github.com/volta-cli/volta/pull/1214), we will need to make changes to the installer script.
* However, until we complete all of the changes and roll out a new release, we don't want to disrupt the existing installer for the existing Volta versions.
* To prevent modifications in the repo from affecting the live installer, we can pin the redirect to a specific commit hash.

# Changes

* Updated the Netlify config to redirect to the current latest commit hash, instead of relying on the HEAD of the `main` branch.