### PR TITLE
Update pin to point to Volta 1.1.0 installer

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [[redirects]]
   from = "/*"
 # FIXME: we should still use a function so this works from browsers too, and redirects to an MSI for Windows
-  to = "https://raw.githubusercontent.com/volta-cli/volta/8f2074f423c65405dfba9858d9bcf393c38ffb45/dev/unix/volta-install.sh"
+  to = "https://raw.githubusercontent.com/volta-cli/volta/c900e251223f584b9a463a3081a2dd0764fb274a/dev/unix/volta-install.sh"
   status = 200


### PR DESCRIPTION
Info
-----
* For the release of Volta 1.1.0, we want to update the `get.volta.sh` redirect to point at the updated installer.
* Rather than updating to point to `main`, it feels like a better approach is to pin it to the current latest installer.
* Then in the future, if we update the installer, we can separately update this pin. That way we can be intentional about changes to the installer and not have to do a new pin before committing PRs.

Notes
-----
* Should be merged at the same time as `latest-version` is updated in the website repo