### PR TITLE
Bump pinned installer to correctly handle architecture check

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [[redirects]]
   from = "/*"
 # FIXME: we should still use a function so this works from browsers too, and redirects to an MSI for Windows
-  to = "https://raw.githubusercontent.com/volta-cli/volta/0014c3ff1b7a285a137761c7fa92a2c53baa73c7/dev/unix/volta-install.sh"
+  to = "https://raw.githubusercontent.com/volta-cli/volta/71c07280729f54b78d9eff79d3e3c8aef8b29dce/dev/unix/volta-install.sh"
   status = 200


### PR DESCRIPTION
After releasing Volta 2.0.0, an issue was reported with the installer where it was incorrectly exiting early on Linux ARM, even though that should be supported. The fix to the installer was committed in https://github.com/volta-cli/volta/pull/1838, so the `get.volta.sh` script needs to be updated to point at the fixed installer as well.